### PR TITLE
Add fs2-http

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ Totally a WIP (like all my other projects).
 - [Simplified Http](https://github.com/scalaj/scalaj-http)
 - [naive-http](https://github.com/timt/naive-http)
 - [Spray](http://spray.io/documentation/1.2.4/spray-client/)
+- [fs2-http](https://github.com/Spinoco/fs2-http)
 
 [![Build Status](https://travis-ci.org/mfirry/scala-http-clients.png?branch=master)](https://travis-ci.org/mfirry/scala-http-clients)

--- a/build.sbt
+++ b/build.sbt
@@ -99,4 +99,13 @@ lazy val spray =
       )
     )
 
+lazy val `fs2-http` =
+  (project in file("fs2-http"))
+    .settings(
+      scalaVersion := "2.11.8",
+      libraryDependencies ++= Seq(
+        "com.spinoco" %% "fs2-http" % "0.1.3"
+      )
+    )
+
 reformatOnCompileSettings

--- a/fs2-http/src/main/scala/com/example/Fs2Http.scala
+++ b/fs2-http/src/main/scala/com/example/Fs2Http.scala
@@ -1,0 +1,44 @@
+package com.example
+
+import fs2._
+import fs2.util.syntax._
+import spinoco.fs2.http
+import spinoco.fs2.http.HttpRequest
+import spinoco.protocol.http.header.value.{HeaderCodecDefinition, HttpMediaRange}
+// import spinoco.fs2.http.Resources._ // use when updating to 0.1.4
+import spinoco.protocol.http.Uri
+import spinoco.protocol.http.header.value.AgentVersion
+import spinoco.protocol.http.header._
+import spinoco.protocol.http.header.value.MediaType
+
+object Fs2Http extends App {
+
+  // TO BE REMOVED AFTER UPGRADE TO 0.1.4 - BEGIN
+  import java.nio.channels.AsynchronousChannelGroup
+  import java.util.concurrent.Executors
+  import fs2.{Scheduler, Strategy}
+
+  val ES = Executors.newCachedThreadPool(Strategy.daemonThreadFactory("AG"))
+  implicit val S = Strategy.fromExecutor(ES)
+  implicit val Sch = Scheduler.fromScheduledExecutorService(Executors.newScheduledThreadPool(4, Strategy.daemonThreadFactory("S")))
+  implicit val AG = AsynchronousChannelGroup.withThreadPool(ES)
+  // TO BE REMOVED AFTER UPGRADE TO 0.1.4 - END
+
+
+  val task = http.client[Task]().flatMap { client =>
+
+    val request = HttpRequest
+      .get[Task](Uri.https("github.com", "/scala-italy"))
+      // .get[Task](Uri.https("api.github.com", "/users/scala-italy"))
+      // .withHeader(Accept(List(HttpMediaRange.One(MediaType.`application/json`, None))))
+      .withHeader(`User-Agent`(AgentVersion("Awesome-Octocat-App")))
+
+    client.request(request).flatMap { resp =>
+      Stream.eval(resp.bodyAsString)
+    }.runLog.map {
+      println
+    }
+  }
+
+  task.unsafeAttemptRun()
+}


### PR DESCRIPTION
This PR simply add `fs2-http` as an example of `HTTP GET`.

Unfortunately with the version `0.1.3` of `fs2-http` I am not able to make it accept `application/json` content...  🤞 version `0.1.4`.